### PR TITLE
Fix password validation in change modal and regex

### DIFF
--- a/frontend/src/helpers/validation.helper.ts
+++ b/frontend/src/helpers/validation.helper.ts
@@ -3,6 +3,7 @@ export const LATIN_LETTER_ONLY = '(only Latin letters allowed)';
 export const DIGITS_LATIN_LETTERS_ONLY = '(only digits, Latin letters allowed)';
 export const EMAIL_MESSAGE = `Email length must be 4-320(with @) symbols ${DIGITS_LATIN_LETTERS_SPEC_CHARS_ONLY}.`;
 export const PASSWORD_MESSAGE = `Password length must be 5-32 symbols ${DIGITS_LATIN_LETTERS_SPEC_CHARS_ONLY}.`;
+export const NEW_CURRENT_PASSWORDS_MATCH = 'New and current passwords match.';
 export const PASSWORDS_NOT_MATCH = 'Passwords do not match.';
 export const NICKNAME_MESSAGE = `Nickname must be 1-30 symbols ${DIGITS_LATIN_LETTERS_ONLY}.`;
 export const NICKNAME_ENGAGED_MESSAGE = 'This nickname is already in use. Please, choose another one.';
@@ -11,7 +12,7 @@ export const SURNAME_MESSAGE = `Surname must be 1-30 symbols ${LATIN_LETTER_ONLY
 
 /* eslint-disable max-len */
 const emailRegex = /^(([!#$%&'*+-/=?^_`{|A-Za-z0-9]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|((?![-])([a-zA-Z\-0-9]+\.)+[a-zA-Z]{1,}))$/;
-const passwordRegex = /^(?=^.{5,32}$)(?=\S+$).+$/;
+const passwordRegex = /^[!@#$%&'":;*+-/\\=?^_`{}|().<>A-Za-z0-9]*$/;
 const userNameSurnameRegex = /^[A-Za-z]+(-[A-Za-z]+)*$/;
 const userNicknameRegex = /^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$/;
 

--- a/frontend/src/screens/ProfilePage/components/PasswordChangeModal/index.tsx
+++ b/frontend/src/screens/ProfilePage/components/PasswordChangeModal/index.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { Form, Modal } from 'semantic-ui-react';
 import { IBindingCallback1 } from '@models/Callbacks';
 import {
-  isValidPassword,
+  isValidPassword, NEW_CURRENT_PASSWORDS_MATCH,
   PASSWORD_MESSAGE, PASSWORDS_NOT_MATCH
 } from '@helpers/validation.helper';
 import InputPopup from '@components/InputPopup';
@@ -38,7 +38,8 @@ const PasswordChangeModal: FunctionComponent<IPasswordChangeModalProps> = ({
   const validationInitialState = {
     isPasswordValid: true,
     isNewPasswordValid: true,
-    isPasswordsMatch: true
+    isPasswordsMatch: true,
+    isNewAndCurrentDifferent: true
   };
 
   const initialInputTypes = {
@@ -80,6 +81,8 @@ const PasswordChangeModal: FunctionComponent<IPasswordChangeModalProps> = ({
       case 'isPasswordValid': {
         setValidationData(prevState => ({ ...prevState,
           [fieldId]: isValidPassword(val) }));
+        setValidationData(prevState => ({ ...prevState,
+          isNewAndCurrentDifferent: passwordChangeForm.newPassword !== val }));
         break;
       }
       case 'isNewPasswordValid': {
@@ -87,6 +90,8 @@ const PasswordChangeModal: FunctionComponent<IPasswordChangeModalProps> = ({
           { ...prevState, [fieldId]: isValidPassword(val) }));
         setValidationData(prevState => ({ ...prevState,
           isPasswordsMatch: passwordChangeForm.repeatPassword === val }));
+        setValidationData(prevState => ({ ...prevState,
+          isNewAndCurrentDifferent: passwordChangeForm.password !== val }));
         break;
       }
       case 'isPasswordsMatch': {
@@ -149,8 +154,8 @@ const PasswordChangeModal: FunctionComponent<IPasswordChangeModalProps> = ({
                 setValue={val => updatePasswordChangeForm('newPassword', val)}
                 validateValue={val => updateValidationData('isNewPasswordValid', val)}
                 disabled={!modalData.isChangePasswordFormLoaded}
-                isValueValid={validationData.isNewPasswordValid}
-                errorMessage={PASSWORD_MESSAGE}
+                isValueValid={validationData.isNewPasswordValid && validationData.isNewAndCurrentDifferent}
+                errorMessage={!validationData.isNewPasswordValid ? PASSWORD_MESSAGE : NEW_CURRENT_PASSWORDS_MATCH}
               />
               <InputButton onToggleInput={() => handleToggleInput('newPasswordInputType',
                 inputTypes.newPasswordInputType)}


### PR DESCRIPTION
Fix validation of passwords for entering Cyrillic.
Fix when the password changes successfully if you enter the current password in the new password entry fields in the password change window on the profile page.